### PR TITLE
add --modules option to the playbook invocation

### DIFF
--- a/lib/charms/layer/task.py
+++ b/lib/charms/layer/task.py
@@ -198,6 +198,8 @@ class Runner(object):
         if extra_vars:
             extra = ["%s=%s" % (k, v) for k, v in extra_vars.items()]
             self.callme += ['--extra-vars', '"%s"' % (' '.join(extra))]
+        if self.options.module_path:
+            self.callme += ['--module-path',self.options.module_path]
 
     def run(self):
         # Results of PlaybookExecutor


### PR DESCRIPTION
This pull requests forces the library path specified in ansible.cfg to be added to the ansible-playbook invocation via the --modules option.

@fengxia41103 -- for your consideration. 